### PR TITLE
Add option for colons in the time zone separator

### DIFF
--- a/ISO8601DateFormatter.h
+++ b/ISO8601DateFormatter.h
@@ -31,6 +31,12 @@ enum {
 };
 typedef NSUInteger ISO8601DateFormat;
 
+enum {
+	ISO8601DateFormatterTimeZoneSeparatorNone,
+	ISO8601DateFormatterTimeZoneSeparatorColon,
+};
+typedef NSUInteger ISO8601DateFormatterTimeZoneSeparator;
+
 //The default separator for time values. Currently, this is ':'.
 extern unichar ISO8601DefaultTimeSeparatorCharacter;
 
@@ -72,6 +78,7 @@ extern unichar ISO8601DefaultTimeSeparatorCharacter;
 @property ISO8601DateFormat format;
 @property BOOL includeTime;
 @property unichar timeSeparator;
+@property ISO8601DateFormatterTimeZoneSeparator timeZoneSeparator; // Default is no separator between the time zone components
 
 - (NSString *) stringFromDate:(NSDate *)date;
 - (NSString *) stringFromDate:(NSDate *)date timeZone:(NSTimeZone *)timeZone;

--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -20,7 +20,8 @@ unichar ISO8601DefaultTimeSeparatorCharacter = DEFAULT_TIME_SEPARATOR;
 #define ISO_TIME_WITH_TIMEZONE_FORMAT  ISO_TIME_FORMAT @"Z"
 //printf formats.
 #define ISO_TIMEZONE_UTC_FORMAT @"Z"
-#define ISO_TIMEZONE_OFFSET_FORMAT @"%+.2d%.2d"
+#define ISO_TIMEZONE_OFFSET_FORMAT_NONE @"%+.2d%.2d"
+#define ISO_TIMEZONE_OFFSET_FORMAT_COLON @"%+.2d:%.2d"
 
 @interface ISO8601DateFormatter(UnparsingPrivate)
 
@@ -700,8 +701,10 @@ static BOOL is_leap_year(NSUInteger year);
 		offset /= 60;  //bring down to minutes
 		if (offset == 0)
 			str = [str stringByAppendingString:ISO_TIMEZONE_UTC_FORMAT];
+		else if (self.timeZoneSeparator == ISO8601DateFormatterTimeZoneSeparatorColon)
+			str = [str stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT_COLON, (int)(offset / 60), (int)(offset % 60)];
 		else
-			str = [str stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT, (int)(offset / 60), (int)(offset % 60)];
+			str = [str stringByAppendingFormat:ISO_TIMEZONE_OFFSET_FORMAT_NONE, (int)(offset / 60), (int)(offset % 60)];
 	}
 
 	//Undo the change we made earlier


### PR DESCRIPTION
ISO8601 says the time zone can have colons separating the components of the time zone separator. This adds an enum and property to set if you want to use colons or not. The default is not, as to not change the current functionality without explicitly setting this option.
