### PR TITLE
Performance problem caused by NSDateFormatter always created

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -678,7 +678,7 @@ static BOOL is_leap_year(NSUInteger year);
 
 	unparsingCalendar.timeZone = timeZone;
 
-	if (dateFormat != lastUsedFormatString) {
+	if ([dateFormat isEqualToString:lastUsedFormatString] == NO) {
 		[unparsingFormatter release];
 		unparsingFormatter = nil;
 


### PR DESCRIPTION
When includeTime property is YES, parameter dateFormat is recreated.

So : dateFormat == lastUsedFormatString is false.

Replacing by [dateFormat isEqualToString:lastUsedFormatString]
