### PR TITLE
Specify a locale of en_US_POSIX to avoid localization problems in certain situations

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -706,6 +706,7 @@ static BOOL is_leap_year(NSUInteger year);
 		unparsingFormatter.formatterBehavior = NSDateFormatterBehavior10_4;
 		unparsingFormatter.dateFormat = dateFormat;
 		unparsingFormatter.calendar = unparsingCalendar;
+		unparsingFormatter.locale = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"] autorelease];
 	}
 
 	unparsingCalendar.timeZone = timeZone;
@@ -804,6 +805,7 @@ static BOOL is_leap_year(NSUInteger year);
 		unichar timeSep = self.timeSeparator;
 		if (!timeSep) timeSep = ISO8601DefaultTimeSeparatorCharacter;
 		formatter.dateFormat = [self replaceColonsInString:ISO_TIME_WITH_TIMEZONE_FORMAT withTimeSeparator:timeSep];
+		formatter.locale = [[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"] autorelease];
 
 		timeString = [formatter stringForObjectValue:date];
 


### PR DESCRIPTION
Specify a locale of en_US_POSIX to avoid localization problems in certain situations, documented by Apple at https://developer.apple.com/library/ios/qa/qa1480/_index.html .  This was seen in testing with iOS, when using a British English current locale and choosing a 12-hour date preference in Settings.  NSDateFormatter actually rewrote the format to output "hh a" despite the request to print out "HH".  Using the POSIX locale ensures the output is not subject to user preferences, which is desired when printint out an ISO6801 compliant format.

Whoops, I didn't see the existing pull request.  If they managed to get a unit test, that is better, but I think it is missing another place where the locale could be specified.
