### PR TITLE
Ignore date strings that contain slashes

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -155,7 +155,8 @@ static BOOL is_leap_year(NSUInteger year);
 	return [self dateComponentsFromString:string timeZone:outTimeZone range:NULL fractionOfSecond:NULL];
 }
 - (NSDateComponents *) dateComponentsFromString:(NSString *)string timeZone:(out NSTimeZone **)outTimeZone range:(out NSRange *)outRange fractionOfSecond:(out NSTimeInterval *)outFractionOfSecond {
-	if (string == nil)
+    // Bail immediately if asked to parse a `nil` string or if the string contains a slash delimiter (we don't support ISO-8601 intervals)
+	if (string == nil || [string rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"/"]].location != NSNotFound)
 		return nil;
 
 	NSDate *now = [NSDate date];


### PR DESCRIPTION
This change causes the parser to bail out in the event it encounters a date string like '11/27/1982'. Currently the parser will incorrectly digest it and treat the year as 1011. As I understand it, slashes only appear in time intervals in ISO 8601 date strings.
