### PR TITLE
Legacy runtime support

### DIFF
--- a/ISO8601DateFormatter.h
+++ b/ISO8601DateFormatter.h
@@ -47,6 +47,7 @@ extern const unichar ISO8601DefaultTimeSeparatorCharacter;
 	NSTimeZone *defaultTimeZone;
 	ISO8601DateFormat format;
 	unichar timeSeparator;
+    unichar timeZoneSeparator;
 	BOOL includeTime;
 	BOOL parsesStrictly;
 }

--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -706,6 +706,7 @@ static BOOL is_leap_year(NSUInteger year);
 @synthesize format;
 @synthesize includeTime;
 @synthesize timeSeparator;
+@synthesize timeZoneSeparator;
 
 - (NSString *) replaceColonsInString:(NSString *)timeFormat withTimeSeparator:(unichar)timeSep {
 	if (timeSep != ':') {


### PR DESCRIPTION
These patches make the formatter work for Mac apps targeting the legacy (32 bit) runtime again
