### PR TITLE
Import float.h to get hold of DBL_EPSILON

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -4,6 +4,7 @@
  *Copyright 2009–2013 Peter Hosey. All rights reserved.
  */
 
+#import <float.h>
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #	import <UIKit/UIKit.h>


### PR DESCRIPTION
DBL_EPSILON is defined in float.h and I was getting a compile error that
it wasn't defined.

Fixes #34 
