### PR TITLE
Simplify code by using copy-on-write for the immutable time zone cache

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -26,7 +26,6 @@ const unichar ISO8601DefaultTimeSeparatorCharacter = DEFAULT_TIME_SEPARATOR;
 #define ISO_TIMEZONE_OFFSET_FORMAT_WITH_SEPARATOR @"%+.2d%C%.2d"
 
 @interface ISO8601DateFormatter ()
-+ (void) createGlobalCachesThatDoNotAlreadyExist;
 //Used when a memory warning occurs (if at least one ISO 8601 Date Formatter exists at the time).
 + (void) purgeGlobalCaches;
 @end
@@ -40,40 +39,25 @@ const unichar ISO8601DefaultTimeSeparatorCharacter = DEFAULT_TIME_SEPARATOR;
 
 @end
 
-@interface ISO8601TimeZoneCache: NSObject
-{}
-
-//The property being read-only means that the formatter cannot change the cache's dictionary, but the formatter is explicitly allowed to mutate the dictionary.
-@property(nonatomic, readonly, strong) NSMutableDictionary *timeZonesByOffset;
-
-@end
-
-static ISO8601TimeZoneCache *timeZoneCache;
+static NSDictionary *timeZonesByOffset;
 
 #if ISO8601_TESTING_PURPOSES_ONLY
 //This method only exists for use by the project's test cases. DO NOT use this in an application.
 extern bool ISO8601DateFormatter_GlobalCachesAreWarm(void);
 
 bool ISO8601DateFormatter_GlobalCachesAreWarm(void) {
-	return (timeZoneCache != nil) && (timeZoneCache.timeZonesByOffset.count > 0);
+	return (timeZonesByOffset != nil) && (timeZonesByOffset.count > 0);
 }
 #endif
 
 @implementation ISO8601DateFormatter
-+ (void) initialize {
-	[self createGlobalCachesThatDoNotAlreadyExist];
-}
-
-+ (void) createGlobalCachesThatDoNotAlreadyExist {
-	if (!timeZoneCache) {
-		timeZoneCache = [[ISO8601TimeZoneCache alloc] init];
-	}
-}
 
 + (void) purgeGlobalCaches {
-	ISO8601TimeZoneCache *oldCache = timeZoneCache;
-	timeZoneCache = nil;
-	[oldCache release];
+    @synchronized (self) {
+        NSDictionary *oldCache = timeZonesByOffset;
+        timeZonesByOffset = nil;
+        [oldCache release];
+    }
 }
 
 - (NSCalendar *) makeCalendarWithDesiredConfiguration {
@@ -607,15 +591,16 @@ static BOOL is_leap_year(NSUInteger year);
 								if (negative) tz_minute = -tz_minute;
 							}
 
-							[[self class] createGlobalCachesThatDoNotAlreadyExist];
-
 							NSInteger timeZoneOffset = (tz_hour * 3600) + (tz_minute * 60);
 							NSNumber *offsetNum = [NSNumber numberWithInteger:timeZoneOffset];
-							timeZone = [timeZoneCache.timeZonesByOffset objectForKey:offsetNum];
+							timeZone = [timeZonesByOffset objectForKey:offsetNum];
 							if (!timeZone) {
 								timeZone = [NSTimeZone timeZoneForSecondsFromGMT:timeZoneOffset];
-								if (timeZone)
-									[timeZoneCache.timeZonesByOffset setObject:timeZone forKey:offsetNum];
+								if (timeZone) {
+                                    NSMutableDictionary *mutableTimeZonesByOffset = [NSMutableDictionary dictionaryWithDictionary:timeZonesByOffset];
+									mutableTimeZonesByOffset[offsetNum] = timeZone;
+                                    timeZonesByOffset = [mutableTimeZonesByOffset copy];
+                                }
 							}
 						}
 				}
@@ -1002,19 +987,3 @@ static BOOL is_leap_year(NSUInteger year) {
 	&& (((year % 100U) != 0U)
 	||  ((year % 400U) == 0U));
 }
-
-static NSString *const ISO8601ThreadStorageTimeZoneCacheKey = @"org.boredzo.ISO8601ThreadStorageTimeZoneCacheKey";
-
-@implementation ISO8601TimeZoneCache: NSObject
-
-- (NSMutableDictionary *) timeZonesByOffset {
-	NSMutableDictionary *threadDict = [NSThread currentThread].threadDictionary;
-	NSMutableDictionary *currentCacheDict = [threadDict objectForKey:ISO8601ThreadStorageTimeZoneCacheKey];
-	if (currentCacheDict == nil) {
-		currentCacheDict = [NSMutableDictionary dictionaryWithCapacity:2UL];
-		[threadDict setObject:currentCacheDict forKey:ISO8601ThreadStorageTimeZoneCacheKey];
-	}
-	return currentCacheDict;
-}
-
-@end


### PR DESCRIPTION
Simplify code by using copy-on-write for the immutable time zone cache dictionary instead of a slower thread local variant.

This references #12 and runs about 15% faster in my quick test. It's also a lot less code and especially no longer needs an initializer to create the cache.

Another way that might be not as fast but would require even less memory would be to simply use an NSCache object instead of the NSDictionary.