### PR TITLE
Added support for millisecond precision

### DIFF
--- a/ISO8601DateFormatter.h
+++ b/ISO8601DateFormatter.h
@@ -49,6 +49,7 @@ extern const unichar ISO8601DefaultTimeSeparatorCharacter;
 	unichar timeSeparator;
     unichar timeZoneSeparator;
 	BOOL includeTime;
+	BOOL useMillisecondPrecision;
 	BOOL parsesStrictly;
 }
 
@@ -169,6 +170,13 @@ extern const unichar ISO8601DefaultTimeSeparatorCharacter;
  *	@sa	timeZoneSeparator
  */
 @property BOOL includeTime;
+/*!
+ *	@brief	Whether strings should include millisecond precision time.
+ *
+ *	@details	If `YES`, strings include three millisecond digits. Only has an effect if `includeTime` is `YES`
+ *
+ */
+@property BOOL useMillisecondPrecision;
 /*!
  *	@brief	The character to use to separate components of the time of day.
  *


### PR DESCRIPTION
I am using an API that needs dates formatted with millisecond precision, e.g. `2014-09-10T14:00:00.000Z`. I've added a `useMillisecondPrecision` property which allows you to format dates like this.
