### PR TITLE
watchOS Compilation Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
     - cd ISO8601ForCocoa
 script:
     - xcodebuild test -scheme 'ISO8601ForCocoa' SRCROOT=../build OBJROOT=../build SHARED_PRECOMPS_DIR=../build
-    - xcodebuild test -scheme 'ISO8601ForCocoaTouch' -destination 'name=iPhone Retina (4-inch 64-bit)' SRCROOT=../build OBJROOT=../build SHARED_PRECOMPS_DIR=../build
+    - xcodebuild test -scheme 'ISO8601ForCocoaTouch' -destination 'name=iPhone 6' SRCROOT=../build OBJROOT=../build SHARED_PRECOMPS_DIR=../build
 after_success:
     - cd ..
     - coveralls -x '.m'

--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -98,7 +98,7 @@ bool ISO8601DateFormatter_GlobalCachesAreWarm(void) {
 		parsesStrictly = NO;
 		useMillisecondPrecision = NO;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_IOS) || TARGET_OS_IOS)
 		[[NSNotificationCenter defaultCenter] addObserver:self
 			selector:@selector(didReceiveMemoryWarning:)
 			name:UIApplicationDidReceiveMemoryWarningNotification
@@ -109,7 +109,7 @@ bool ISO8601DateFormatter_GlobalCachesAreWarm(void) {
 }
 
 - (void) dealloc {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_IOS) || TARGET_OS_IOS)
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 #endif
 


### PR DESCRIPTION
Currently, `master` cannot be compiled for watchOS because it attempts to deal with an `UIApplication` memory warning. The memory warning and the class `UIApplication` are both unavailable on watchOS.

This pull request ensures that a watchOS compilation does not try to compile this existing code.

Notes:
* `TARGET_OS_IPHONE` is defined and true for both iOS and watchOS
* `TARGET_OS_IOS` is a _new_ flag in the iOS 9/watchOS 2 SDKs that is only true for iOS compilation
* There is another _new_ flag that is `TARGET_OS_WATCH`, but it would be odd to conditionally exclude something that is specifically for one platform

This PR could have been simplified by doing `#if TARGET_OS_IOS` and removing `TARGET_OS_IPHONE` altogether, but that would cause issues for previous SDKs. This approach works for current, past, and “future” SDK/Xcode versions.