### PR TITLE
Replace NSUndefinedDateComponent with NSDateComponentUndefined

### DIFF
--- a/ISO8601DateFormatter.m
+++ b/ISO8601DateFormatter.m
@@ -172,11 +172,11 @@ static BOOL is_leap_year(NSUInteger year);
 
 	NSUInteger
 		//Date
-		year = NSUndefinedDateComponent,
-		month_or_week = NSUndefinedDateComponent,
-		day = NSUndefinedDateComponent,
+		year = NSDateComponentUndefined,
+		month_or_week = NSDateComponentUndefined,
+		day = NSDateComponentUndefined,
 		//Time
-		hour = NSUndefinedDateComponent;
+		hour = NSDateComponentUndefined;
 	NSTimeInterval
 		minute = NAN,
 		second = NAN;
@@ -576,8 +576,8 @@ static BOOL is_leap_year(NSUInteger year);
 			components.year = year;
 			components.day = day;
 			components.hour = hour;
-			components.minute = isnan(minute) ? NSUndefinedDateComponent : (NSInteger)minute;
-			components.second = isnan(second) ? NSUndefinedDateComponent : (NSInteger)second;
+			components.minute = isnan(minute) ? NSDateComponentUndefined : (NSInteger)minute;
+			components.second = isnan(second) ? NSDateComponentUndefined : (NSInteger)second;
 
 			if (outFractionOfSecond != NULL) {
 				NSTimeInterval fractionOfSecond = second - (NSInteger)second;


### PR DESCRIPTION
NSUndefinedDateComponent is deprecated from:
- iOS 8
- OS X 10.10
- watchOS 2.0

NSDateComponentUndefined is available from:
- iOS 7
- OS X 10.9
- watchOS 2.0
- tvOS 9.0
