### PR TITLE
Added Carthage/Build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ testparser
 unparse-date
 unparse-ordinaldate
 unparse-weekdate
+
+# Carthage
+Carthage/Build


### PR DESCRIPTION
When using the option `--use-submodules` with Carthage, the `Carthage/Build` directory shows in the submodule after `carthage build` making the submodule dirty.
